### PR TITLE
Provide an option to use Emacs advice system

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,12 @@ that takes effect, but `el-patch` retains a record of both patches,
 meaning they can be inspected and validated individually. See
 [#29](https://github.com/radian-software/el-patch/issues/29).
 
+You may also define patches of functions as `:override` advices
+instead of overriding the original definition. This is done by setting
+`el-patch-use-advice` to a non-nil value (either dynamically around a
+patch or globally). The patched function must have the same name and
+number of arguments as the original function.
+
 ## Usage with byte-compiled init-file
 
 `el-patch` does not need to be loaded at runtime just to define

--- a/el-patch.el
+++ b/el-patch.el
@@ -618,7 +618,7 @@ PATCH-DEFINITION is an unquoted list starting with `defun',
                                  :override (quote ,advice-name))))
               `(el-patch--stealthy-eval
                 ,definition
-                "This function was patched by `el-patch'.")))))))
+                "This definition was patched by `el-patch'.")))))))
 
 ;;;;; Removing patches
 

--- a/el-patch.el
+++ b/el-patch.el
@@ -235,7 +235,7 @@ This function lives halfway between `copy-sequence' and
     tree))
 
 (defun el-patch--advice-name (name variant-name)
-  "Return advice name for a given NAME, TYPE and VARIANT-NAME."
+  "Return advice name for a given NAME and VARIANT-NAME."
   (intern
    (format "%S@%s@el-patch--advice"
            name

--- a/el-patch.el
+++ b/el-patch.el
@@ -152,7 +152,8 @@ loaded. You can toggle the `use-package' integration later using
   :type 'boolean)
 
 (defcustom el-patch-use-advice nil
-  "Non-nil causes el-patch to use Emacs' advice system for patching."
+  "Non-nil causes el-patch to use Emacs' advice system for patching.
+This can be set globally or bound dynamically around a patch."
   :type 'list)
 
 ;;;; Internal variables


### PR DESCRIPTION

Advising is only done when the name of the function is the same as the original one and if  `el-patch-use-advice` contains the relevant type (like `defun`). In this case, a function `*@el-patch-advice` is defined and the original function is advised.

Things to consider:
- How this plays with variants (I don't use them, so I am out of the loop).
- If we want to include a field in `el-patch-deftype-alist` that distinguishes advisable types from the rest, to avoid having the wrong type in `el-patch-use-advice`.
- Currently, I don't change anything in `el-patch--patches` to distinguish between advised vs patched functions.
- There is currently no way to advice some functions but not others (related to the previous point). Perhaps this is desirable?

Once we discuss these points, I will finalize this pull request.