### PR TITLE
Make el-patch-get use the only variant by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Enhancements
+* `el-patch-get` will try and return the only variant of a function
+  when you don't provide a specific `variant`.  This makes it so that
+  you can call functions such as `el-patch-validate` non-interactively
+  without providing `variant`.
+
 ## 3.0 (released 2022-04-17)
 ### Breaking changes
 * The arguments to `el-patch-feature` after the feature name are no


### PR DESCRIPTION
I make significant use of `el-patch-validate` non-interactively in my init file.  These usages broke when I updated to the latest version of el-patch, because an invocation that used to work such as

    (el-patch-validate 'some-function 'defun 'nomsg)

was now unable to look up the patch I had just applied to `some-function`.  I believe this is happening because `el-patch-validate` was allowing you to omit `variant`, and `nil` is not a possible variant.  From reading the code, I believe all variants will be a cons of `(advice name)`.  Therefore when `el-patch-validate` calls `(el-patch-get 'some-function 'defun nil)`, it will never get a result, and `el-patch-validate` will always fail.

`(nil)` *could* perhaps be called "the default variant", but I didn't see it hard coded anywhere else in el-patch, so I wasn't about to start here.  Instead, I made `el-patch-get` (which also makes the `variant` argument optional) use the one and only variant present for the given name.  If more than one variant is present, and the caller didn't supply `variant`, `el-patch-get` now signals an error.  I picked `wrong-type-argument` because it was the standard error closest in spirit to what I was trying to convey, and I didn't feel that this case called for defining a whole new error.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
